### PR TITLE
chore: clean up pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,21 @@
 [tool.poetry]
-name = "apis-instance-sicprod-test"
+name = "apis-instance-sicprod-dev-test"
 version = "0.1.0"
-description = "Generic APIS project for auto devops"
+description = "APIS instance SiCProD test"
 authors = ["Birger Schacht <birger.schacht@oeaw.ac.at>"]
 license = "MIT"
 packages = [{include = "apis_ontology"}]
 
 
 [tool.poetry.dependencies]
-python = ">=3.11,<3.12"
+python = "^3.11"
 django = ">=4.1,<4.2"
-whitenoise = "^5.2.0"
-sentry-sdk = "*"
 gunicorn = "^20.0.4"
 mysqlclient = "^2.0.3"
-django-extensions = "^3.1.3"
-pyzotero = "^1.5.5"
 apis-core = { git = "https://github.com/acdh-oeaw/apis-core-rdf.git", branch = "sicprod" }
 webpage = { git = "https://github.com/acdh-oeaw/apis-webpage.git", branch = "main" }
 apis-bibsonomy = { git = "https://github.com/acdh-oeaw/apis-bibsonomy.git", branch = "birger/fix-referenceonform-issues" }
-apis-acdhch-default-settings = { git = "https://github.com/acdh-oeaw/apis-acdhch-default-settings.git", tag = "v0.1.1" }
+apis-acdhch-default-settings = { git = "https://github.com/acdh-oeaw/apis-acdhch-default-settings.git", tag = "v0.1.2" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
* Set the correct name and a more meaningful description
* Loosen the Python requirement
* Remove whitenoise, sentry-sdk, gunicorn, django-extensions and
  pyzotero
* Bump the dependency of apis-acdhch-default-settings to 0.1.2
